### PR TITLE
Miscellaneous stability improvements.

### DIFF
--- a/cmd/backup/config.yaml
+++ b/cmd/backup/config.yaml
@@ -1,4 +1,4 @@
-tempDir: /tmp/backups
+tempDir: /tmp/staging
 deltasPerFile: 10000
 backupThreshold: 100
 concurrentBasebackups: 5
@@ -8,11 +8,12 @@ publication: mypub
 sendStatusOnCommit: false
 initialBasebackup: true
 fsync: false
-archiveDir: /tmp/backup2
+archiveDir: /tmp/final
 forceBasebackupAfterInactivityInterval: 24h
+archiverTimeout: 3h
 db:
-    host: 127.0.0.1
-    port: 5432
-    database: demo
-    user: mkabilov
+  host: 127.0.0.1
+  port: 5432
+  database: postgres
+  user: postgres
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,6 +24,7 @@ type Config struct {
 	Fsync                                  bool           `yaml:"fsync"`
 	ArchiveDir                             string         `yaml:"archiveDir"`
 	ForceBasebackupAfterInactivityInterval time.Duration  `yaml:"forceBasebackupAfterInactivityInterval"`
+	ArchiverTimeout                        time.Duration  `yaml:"archiverTimeout"`
 }
 
 func New(filename string) (*Config, error) {

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -3,7 +3,6 @@ package tablebackup
 import (
 	"database/sql"
 	"fmt"
-	"github.com/ikitiki/logical_backup/pkg/utils"
 	"io/ioutil"
 	"log"
 	"os"
@@ -15,6 +14,7 @@ import (
 	"gopkg.in/yaml.v2"
 
 	"github.com/ikitiki/logical_backup/pkg/message"
+	"github.com/ikitiki/logical_backup/pkg/utils"
 )
 
 func (t *TableBackup) RunBasebackup() error {

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -3,12 +3,11 @@ package tablebackup
 import (
 	"database/sql"
 	"fmt"
+	"github.com/ikitiki/logical_backup/pkg/utils"
 	"io/ioutil"
 	"log"
 	"os"
 	"path"
-	"strconv"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -18,7 +17,11 @@ import (
 	"github.com/ikitiki/logical_backup/pkg/message"
 )
 
-func (t *TableBackup) Basebackup() error {
+func (t *TableBackup) RunBasebackup() error {
+	var (
+		backupLSN, preBackupLSN, postBackupLSN uint64
+	)
+
 	if !atomic.CompareAndSwapUint32(&t.locker, 0, 1) {
 		log.Printf("Already locked %s; skipping", t)
 		return nil
@@ -28,7 +31,7 @@ func (t *TableBackup) Basebackup() error {
 	}()
 
 	log.Printf("Starting base backup of %s", t)
-	tempFilepath := path.Join(t.tableDir, t.infoFilename+".new")
+	tempFilepath := path.Join(t.tempDir, t.infoFilename+".new")
 	if _, err := os.Stat(tempFilepath); os.IsExist(err) {
 		os.Remove(tempFilepath)
 	}
@@ -53,44 +56,64 @@ func (t *TableBackup) Basebackup() error {
 	}
 	defer t.disconnect()
 
-	if err := t.txBegin(); err != nil {
-		return fmt.Errorf("could not start transaction: %v", err)
-	}
-
 	startTime := time.Now()
+	var relationInfo message.Relation
 
-	if err := t.createTempReplicationSlot(); err != nil { // slot will be dropped on tx finish
-		return fmt.Errorf("could not create replication slot: %v", err)
-	}
+	stop, err := func() (stop bool, err error) {
+		if err := t.txBegin(); err != nil {
+			return true, fmt.Errorf("could not start transaction: %v", err)
+		}
 
-	if err := t.lockTable(); err != nil {
-		return fmt.Errorf("could not lock table: %v", err)
-	}
+		defer func() {
+			if stop || err != nil {
+				if err := t.txRollback(); err != nil {
+					fmt.Printf("could not rollback: %v", err)
+				}
+			} else {
+				if err := t.txCommit(); err != nil {
+					stop = true
+					err = fmt.Errorf("could not commit: %v", err)
 
-	//TODO: check if table is empty before creating logical replication slot
-	if hasRows, err := t.hasRows(); err != nil {
-		return fmt.Errorf("could not check if table has rows: %v", err)
-	} else if !hasRows {
-		log.Printf("table %s seems to have no rows; skipping", t.Identifier)
-		return nil
-	}
+				}
+			}
+		}()
+		preBackupLSN = t.lastLSN
+		backupLSN, err = t.createTempReplicationSlot()
+		if err != nil { // slot will be dropped on tx finish
+			return true, fmt.Errorf("could not create replication slot: %v", err)
+		}
+		postBackupLSN = t.lastLSN
 
-	relationInfo, err := FetchRelationInfo(t.tx, t.Identifier)
-	if err != nil {
-		return fmt.Errorf("could not fetch table struct: %v", err)
-	}
+		if err := t.lockTable(); err != nil {
+			return true, fmt.Errorf("could not lock table: %v", err)
+		}
 
-	if err := t.copyDump(); err != nil {
-		return fmt.Errorf("could not dump table: %v", err)
-	}
+		//TODO: check if table is empty before creating logical replication slot
+		if hasRows, err := t.hasRows(); err != nil {
+			return true, fmt.Errorf("could not check if table has rows: %v", err)
+		} else if !hasRows {
+			log.Printf("table %s seems to have no rows; skipping", t.Identifier)
+			return true, nil
+		}
 
-	if err := t.txCommit(); err != nil {
-		return fmt.Errorf("could not commit: %v", err)
+		relationInfo, err = FetchRelationInfo(t.tx, t.Identifier)
+		if err != nil {
+			return true, fmt.Errorf("could not fetch table struct: %v", err)
+		}
+
+		if err := t.copyDump(); err != nil {
+			return true, fmt.Errorf("could not dump table: %v", err)
+		}
+
+		return false, nil
+	}()
+	if stop {
+		return err
 	}
 
 	t.lastBackupDuration = time.Since(startTime)
 	err = yaml.NewEncoder(infoFp).Encode(message.DumpInfo{
-		StartLSN:       pgx.FormatLSN(t.basebackupLSN),
+		StartLSN:       pgx.FormatLSN(backupLSN),
 		CreateDate:     time.Now(),
 		Relation:       relationInfo,
 		BackupDuration: t.lastBackupDuration.Seconds(),
@@ -99,23 +122,67 @@ func (t *TableBackup) Basebackup() error {
 		return fmt.Errorf("could not save info file: %v", err)
 	}
 
-	if err := os.Rename(tempFilepath, path.Join(t.tableDir, t.infoFilename)); err != nil {
+	if err := os.Rename(tempFilepath, path.Join(t.tempDir, t.infoFilename)); err != nil {
 		log.Printf("could not rename: %v", err)
 	}
+
+	// remove all deltas before this point, but keep the latest delta started before the backup, because it may
+	// have changes happening after the backup has started. There is a slight race of a race condition, if a delta
+	// file gets rotated after creation of the slot but before the LSN to keep is recorded; to avoid that, we keep
+	// the LSN before and after the logical slot creation and, in case of their mismatch, take the latest delta
+	// file that has been created before the slot. Since changes to firstDeltaLSNToKeep are effective right away on the
+	// archiver side we go extra mile not to assign intermediate results to it.
+
+	candidateLSN := postBackupLSN
+
+	if candidateLSN > backupLSN {
+		log.Printf("first delta lsn to keep %s is higher than the backup lsn %s, attempting the previous delta lsn %s",
+			pgx.FormatLSN(postBackupLSN), pgx.FormatLSN(backupLSN), pgx.FormatLSN(preBackupLSN))
+		// lookd like the slot that has been created after the delta segment got an LSN that is lower than that segment!
+		if preBackupLSN > backupLSN {
+			log.Fatalf("logical slot lsn %s points to an earlier location than the lsn of the latest delta created before the slot %s",
+				pgx.FormatLSN(backupLSN), pgx.FormatLSN(t.firstDeltaLSNToKeep))
+		}
+		candidateLSN = preBackupLSN
+	}
+
+	// Make sure we have a cutoff point
+	if candidateLSN == 0 {
+		log.Printf("first delta to keep lsn is not defined, reverting to the backup lsn %s",
+			pgx.FormatLSN(backupLSN))
+		candidateLSN = backupLSN
+	}
+
+	t.firstDeltaLSNToKeep = candidateLSN
 
 	t.archiveFiles <- t.infoFilename
 
 	log.Printf("%s backed up in %v; start lsn: %s",
-		t.String(), t.lastBackupDuration.Truncate(1*time.Second), pgx.FormatLSN(t.basebackupLSN))
+		t.String(), t.lastBackupDuration.Truncate(1*time.Second), pgx.FormatLSN(backupLSN))
 
-	if err := t.RotateOldDeltas(path.Join(t.tableDir, deltasDir), t.lastLSN); err != nil {
-		return fmt.Errorf("could not archive old deltas: %v", err)
+	// not that the archiver has stopped archiving old deltas, we can purge them from both staging and final directories
+	for _, basedir := range []string{t.tempDir, t.finalDir} {
+		if err := t.PurgeObsoleteDeltaFiles(path.Join(basedir, deltasDirName)); err != nil {
+			return fmt.Errorf("could not purge delta files from %q: %v", path.Join(basedir, deltasDirName), err)
+		}
 	}
 
 	t.lastBasebackupTime = time.Now()
 	t.deltasSinceBackupCnt = 0
 
 	return nil
+}
+
+func (t *TableBackup) SetBasebackupPending() {
+	t.basebackupIsPending = true
+}
+
+func (t *TableBackup) ClearBasebackupPending() {
+	t.basebackupIsPending = false
+}
+
+func (t *TableBackup) IsBasebackupPending() bool {
+	return t.basebackupIsPending
 }
 
 // connects to the postgresql instance using replication protocol
@@ -152,32 +219,24 @@ func (t *TableBackup) tempSlotName() string {
 	return fmt.Sprintf("tempslot_%d", t.conn.PID())
 }
 
-func (t *TableBackup) RotateOldDeltas(deltasDir string, lastLSN uint64) error {
+func (t *TableBackup) PurgeObsoleteDeltaFiles(deltasDir string) error {
+	log.Printf("Purging deltas in %s before the lsn %s",
+		deltasDir, pgx.FormatLSN(t.firstDeltaLSNToKeep))
 	fileList, err := ioutil.ReadDir(deltasDir)
 	if err != nil {
 		return fmt.Errorf("could not list directory: %v", err)
 	}
 	for _, v := range fileList {
 		filename := v.Name()
-		lsnStr := filename
-		if strings.Contains(filename, ".") {
-			parts := strings.Split(filename, ".")
-			lsnStr = parts[0]
-		}
-
-		lsn, err := strconv.ParseUint(lsnStr, 16, 64)
-		if err != nil {
-			return fmt.Errorf("could not parse filename: %v", err)
-		}
-		if lastLSN == lsn {
-			continue // skip current file
-		}
-
-		if lsn < t.basebackupLSN {
-			filename = fmt.Sprintf("%s/%s", deltasDir, filename)
-			if err := os.Remove(filename); err != nil {
-				return fmt.Errorf("could not remove %q file: %v", filename, err)
+		if lsn, err := utils.GetLSNFromDeltaFilename(filename); err == nil {
+			if lsn < t.firstDeltaLSNToKeep {
+				filename = fmt.Sprintf("%s/%s", deltasDir, filename)
+				if err := os.Remove(filename); err != nil {
+					return fmt.Errorf("could not remove %q file: %v", filename, err)
+				}
 			}
+		} else {
+			return fmt.Errorf("could not parse filename: %v", err)
 		}
 	}
 
@@ -251,11 +310,8 @@ func (t *TableBackup) copyDump() error {
 	if t.tx == nil {
 		return fmt.Errorf("no running transaction")
 	}
-	if t.basebackupLSN == 0 {
-		return fmt.Errorf("no consistent point")
-	}
 
-	tempFilename := path.Join(t.tableDir, t.basebackupFilename+".new")
+	tempFilename := path.Join(t.tempDir, t.basebackupFilename+".new")
 	if _, err := os.Stat(tempFilename); os.IsExist(err) {
 		os.Remove(tempFilename)
 	}
@@ -274,7 +330,7 @@ func (t *TableBackup) copyDump() error {
 		os.Remove(tempFilename)
 		return fmt.Errorf("could not copy: %v", err)
 	}
-	if err := os.Rename(tempFilename, path.Join(t.tableDir, t.basebackupFilename)); err != nil {
+	if err := os.Rename(tempFilename, path.Join(t.tempDir, t.basebackupFilename)); err != nil {
 		return fmt.Errorf("could not move file: %v", err)
 	}
 
@@ -283,30 +339,36 @@ func (t *TableBackup) copyDump() error {
 	return nil
 }
 
-func (t *TableBackup) createTempReplicationSlot() error {
+func (t *TableBackup) createTempReplicationSlot() (uint64, error) {
 	var createdSlotName, basebackupLSN, snapshotName, plugin sql.NullString
 
+	var lsn uint64
+
 	if t.tx == nil {
-		return fmt.Errorf("no running transaction")
+		return lsn, fmt.Errorf("no running transaction")
 	}
+
+	// XXX: we don't need to accumulate WAL on the server throughout the whole COPY running time. We need the slot
+	// exclusively to figure out our transaction LSN, why not drop it once we have got it?
 
 	row := t.tx.QueryRow(fmt.Sprintf("CREATE_REPLICATION_SLOT %s TEMPORARY LOGICAL %s USE_SNAPSHOT",
 		t.tempSlotName(), "pgoutput"))
 
 	if err := row.Scan(&createdSlotName, &basebackupLSN, &snapshotName, &plugin); err != nil {
-		return fmt.Errorf("could not scan: %v", err)
+		return lsn, fmt.Errorf("could not scan: %v", err)
 	}
 
 	if !basebackupLSN.Valid {
-		return fmt.Errorf("null consistent point")
+		return lsn, fmt.Errorf("null consistent point")
 	}
 
 	lsn, err := pgx.ParseLSN(basebackupLSN.String)
 	if err != nil {
-		return fmt.Errorf("could not parse LSN: %v", err)
+		return lsn, fmt.Errorf("could not parse LSN: %v", err)
+	}
+	if lsn == 0 {
+		return lsn, fmt.Errorf("no consistent starting point for a dump")
 	}
 
-	t.basebackupLSN = lsn
-
-	return nil
+	return lsn, nil
 }

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -230,7 +230,7 @@ func (t *TableBackup) PurgeObsoleteDeltaFiles(deltasDir string) error {
 		filename := v.Name()
 		if lsn, err := utils.GetLSNFromDeltaFilename(filename); err == nil {
 			if lsn < t.firstDeltaLSNToKeep {
-				filename = fmt.Sprintf("%s/%s", deltasDir, filename)
+				filename = path.Join(deltasDir, filename)
 				if err := os.Remove(filename); err != nil {
 					return fmt.Errorf("could not remove %q file: %v", filename, err)
 				}

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
-	"github.com/jackc/pgx"
-	"github.com/jackc/pgx/pgtype"
 	"io"
 	"log"
 	"os"
@@ -13,6 +11,9 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgtype"
 
 	"github.com/ikitiki/logical_backup/pkg/config"
 	"github.com/ikitiki/logical_backup/pkg/dbutils"

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,9 @@ package utils
 import (
 	"crypto/md5"
 	"fmt"
+	"strconv"
+	"strings"
+	"time"
 
 	"github.com/ikitiki/logical_backup/pkg/message"
 )
@@ -11,4 +14,46 @@ func TableDir(tbl message.Identifier) string {
 	tblHash := fmt.Sprintf("%x", md5.Sum([]byte(tbl.Sanitize())))
 
 	return fmt.Sprintf("%s/%s/%s/%s/%s.%s", tblHash[0:2], tblHash[2:4], tblHash[4:6], tblHash, tbl.Namespace, tbl.Name)
+}
+
+// Retry retries a given function until either it returns false, which indicates success, or the number of attempts
+// reach the limit, or the global timeout is reached. The cool-off period between attempts is passed as well.
+func Retry(fn func() (bool, error), numberOfAttempts int, timeBetweenAttempts time.Duration, totalTimeout time.Duration) error {
+
+	var (
+		globalTicker = time.NewTicker(totalTimeout)
+		fail         = true
+		timeout      bool
+		err          error
+	)
+
+	for i := 0; i < numberOfAttempts; i++ {
+		if fail, err = fn(); err != nil || !fail {
+			break
+		}
+		select {
+		case <-time.After(timeBetweenAttempts):
+		case <-globalTicker.C:
+			timeout = true
+			break
+		}
+	}
+	if !fail || err != nil {
+		return err
+	}
+	if timeout {
+		return fmt.Errorf("did not succeed after %s", totalTimeout)
+	}
+	return fmt.Errorf("did not succeed after %d attempts", numberOfAttempts)
+}
+
+func GetLSNFromDeltaFilename(filename string) (lsn uint64, err error) {
+	lsnStr := filename
+	if strings.Contains(filename, ".") {
+		parts := strings.Split(filename, ".")
+		lsnStr = parts[0]
+	}
+
+	lsn, err = strconv.ParseUint(lsnStr, 16, 64)
+	return
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"crypto/md5"
 	"fmt"
+	"path"
 	"strconv"
 	"strings"
 	"time"
@@ -13,7 +14,8 @@ import (
 func TableDir(tbl message.Identifier) string {
 	tblHash := fmt.Sprintf("%x", md5.Sum([]byte(tbl.Sanitize())))
 
-	return fmt.Sprintf("%s/%s/%s/%s/%s.%s", tblHash[0:2], tblHash[2:4], tblHash[4:6], tblHash, tbl.Namespace, tbl.Name)
+	// TODO: consider removing tblHash altogether to shorten the path
+	return path.Join(tblHash[0:2], tblHash[2:4], tblHash[4:6], tblHash, fmt.Sprintf("%s.%s", tbl.Namespace, tbl.Name))
 }
 
 // Retry retries a given function until either it returns false, which indicates success, or the number of attempts


### PR DESCRIPTION
Introduce the `archiverTimeout` parameter;

The archiverTimeout causes the routine that archives deltas for a table to
close and archive the current file if it receives no changes since the last
one for the duration of the timeout.

Previously, a particular routine of the logical backup called `closeOldFiles`
was responsible for closing all open files after the hard-coded interval of 3h
(that value now servers as a default for the `archiverTimeout`).
Unfortunately, it was doing it in a way that was not concurrency-safe, causing
errors on subsequent writes to that closed file. The tentative fix was to
check if the file was still “active”; this patch implements a more long-term
one of archiving such files on a timeout by the archiver routine. The archiver
employs a new `DeltaFileAccessMutex` to avoid archiving a file that the delta
handler writes.

Make sure the archiver doesn’t block senders to the  `archiveFiles` channel
under load by splitting the archiver code into two routines; the listener one
that puts tasks into the queue, and the worker routine that reads from the
queue and archives files accordingly;

The changes above related to the archiverTimeout added some extra work to the
archiver, and by design, the archiver shouldn't execute any non-trivial tasks
synchronously to be able to read the next filename from the channel without
blocking writers. The changes split the archiver into two parts: one listens
to a channel, puts the filenames into the queue and occasionally (every 10
minutes) wakes up to check if it should close the current file due to the
timeout; the worker part reads delta filenames from the queue and does the
heavy lifting of moving them to the final directory. That split also allows to
handle the archiverTimeout nicely: the main routine closes the file and puts
its name to the queue to archive it later. Also, that allows retrying the
archiving action several times if an error occurs without blocking the writes
to the `archiveFiles` channel.

Close a basebackup transaction when trying to backup a table with no rows;

Previously, the code bailed up without any cleanup, leaving the dump
transaction open and preventing any further backups on the corresponding
tables.

Prevent archiving deltas that precede the latest backups;

The original basebackup code removed those deltas; however, at leat two issues
were present:

The deletion code only considered deltas the final directory, leaving some
files in the temp intact; those deltas would be archived in a later point in
time, making its way to the final directory despite our promise to get rid of
them.

The dump had acquired the WAL log sequence number (lsn), used as a cutoff
point, at the beginning of the dump transaction. That cause deltas for
transactions started before the dump but not committed until after the dump
start to be removed, leading to a data loss. The new code takes the lsn of the
delta file before and after the starting point of the dump and sets the latest
of both that precedes the dump as a cutoff point (usually both should be the
same, unless there is a race condition where the delta is rotated during the
time the dump finds its lsn).

Avoid queuing multiple backups for a single table;

Introduce IsBasebackupPending, SetBasebackupPending and ClearBasebackupPending
methods on a to be used when the backup is queued and dequeued to avoid
queuing the same backup multiple times.