### PR TITLE
Write current deltas into a memory buffer instead of a disk file.

### DIFF
--- a/cmd/backup/config.yaml
+++ b/cmd/backup/config.yaml
@@ -10,7 +10,7 @@ initialBasebackup: true
 fsync: true
 archiveDir: /tmp/final
 forceBasebackupAfterInactivityInterval: 24h
-archiverTimeout: 3m
+archiverTimeout: 3h
 db:
   host: 127.0.0.1
   port: 5432

--- a/cmd/backup/config.yaml
+++ b/cmd/backup/config.yaml
@@ -7,10 +7,10 @@ slotname: myslot
 publication: mypub
 sendStatusOnCommit: false
 initialBasebackup: true
-fsync: false
+fsync: true
 archiveDir: /tmp/final
 forceBasebackupAfterInactivityInterval: 24h
-archiverTimeout: 3h
+archiverTimeout: 3m
 db:
   host: 127.0.0.1
   port: 5432

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -16,6 +16,7 @@ func main() {
 	defer log.Printf("successfully shut down")
 
 	ctx, done := context.WithCancel(context.Background())
+	stopCh := make(chan struct{}, 128)
 
 	if len(os.Args) < 2 {
 		fmt.Printf("usage:\n\t%s {config file}\n", os.Args[0])
@@ -43,7 +44,7 @@ func main() {
 			cfg.ForceBasebackupAfterInactivityInterval)
 	}
 
-	lb, err := logicalbackup.New(ctx, cfg)
+	lb, err := logicalbackup.New(ctx, stopCh, cfg)
 	if err != nil {
 		log.Fatalf("could not create backup instance: %v", err)
 	}
@@ -77,7 +78,7 @@ loop:
 			default:
 				log.Printf("unhandled signal: %v", sig)
 			}
-		case <-lb.TerminationRequest:
+		case <-stopCh:
 			{
 				log.Printf("received termination request, cleaning up...")
 				break loop

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -147,8 +147,8 @@ func (t *TableBackup) RunBasebackup() error {
 			pgx.FormatLSN(postBackupLSN), pgx.FormatLSN(backupLSN), pgx.FormatLSN(preBackupLSN))
 		// lookd like the slot that has been created after the delta segment got an LSN that is lower than that segment!
 		if preBackupLSN > backupLSN {
-			log.Fatalf("logical slot lsn %s points to an earlier location than the lsn of the latest delta created before the slot %s",
-				pgx.FormatLSN(backupLSN), pgx.FormatLSN(t.firstDeltaLSNToKeep))
+			log.Panic("table %s: logical backup lsn %s points to an earlier location than the lsn of the latest delta created before it %s",
+				t, pgx.FormatLSN(backupLSN), pgx.FormatLSN(t.firstDeltaLSNToKeep))
 		}
 		candidateLSN = preBackupLSN
 	}

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -133,7 +133,7 @@ func (t *TableBackup) RunBasebackup() error {
 		log.Printf("could not rename: %v", err)
 	}
 
-	// remove all deltas before this point, but keep the latest delta started before the backup, because it may
+	// remove all segmentBuffer before this point, but keep the latest delta started before the backup, because it may
 	// have changes happening after the backup has started. There is a slight race of a race condition, if a delta
 	// file gets rotated after creation of the slot but before the LSN to keep is recorded; to avoid that, we keep
 	// the LSN before and after the logical slot creation and, in case of their mismatch, take the latest delta
@@ -169,7 +169,7 @@ func (t *TableBackup) RunBasebackup() error {
 		pgx.FormatLSN(backupLSN),
 		pgx.FormatLSN(t.firstDeltaLSNToKeep))
 
-	// not that the archiver has stopped archiving old deltas, we can purge them from both staging and final directories
+	// not that the archiver has stopped archiving old segmentBuffer, we can purge them from both staging and final directories
 	for _, basedir := range []string{t.tempDir, t.finalDir} {
 		if err := t.PurgeObsoleteDeltaFiles(path.Join(basedir, deltasDirName)); err != nil {
 			return fmt.Errorf("could not purge delta files from %q: %v", path.Join(basedir, deltasDirName), err)
@@ -229,7 +229,7 @@ func (t *TableBackup) tempSlotName() string {
 }
 
 func (t *TableBackup) PurgeObsoleteDeltaFiles(deltasDir string) error {
-	log.Printf("Purging deltas in %s before the lsn %s",
+	log.Printf("Purging segments in %s before the lsn %s",
 		deltasDir, pgx.FormatLSN(t.firstDeltaLSNToKeep))
 	fileList, err := ioutil.ReadDir(deltasDir)
 	if err != nil {

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -133,7 +133,7 @@ func (t *TableBackup) RunBasebackup() error {
 		log.Printf("could not rename: %v", err)
 	}
 
-	// remove all segmentBuffer before this point, but keep the latest delta started before the backup, because it may
+	// remove all deltas before this point, but keep the latest delta started before the backup, because it may
 	// have changes happening after the backup has started. There is a slight race of a race condition, if a delta
 	// file gets rotated after creation of the slot but before the LSN to keep is recorded; to avoid that, we keep
 	// the LSN before and after the logical slot creation and, in case of their mismatch, take the latest delta
@@ -169,7 +169,7 @@ func (t *TableBackup) RunBasebackup() error {
 		pgx.FormatLSN(backupLSN),
 		pgx.FormatLSN(t.firstDeltaLSNToKeep))
 
-	// not that the archiver has stopped archiving old segmentBuffer, we can purge them from both staging and final directories
+	// not that the archiver has stopped archiving old deltas, we can purge them from both staging and final directories
 	for _, basedir := range []string{t.tempDir, t.finalDir} {
 		if err := t.PurgeObsoleteDeltaFiles(path.Join(basedir, deltasDirName)); err != nil {
 			return fmt.Errorf("could not purge delta files from %q: %v", path.Join(basedir, deltasDirName), err)

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -191,6 +191,7 @@ func (t *TableBackup) writeSegmentToFile() error {
 		return fmt.Errorf("could not open file %s to write delta segment: %v", deltaPath)
 	}
 	defer fp.Close()
+
 	if _, err = t.segmentBuffer.WriteTo(fp); err != nil {
 		return fmt.Errorf("could not write delta segment to a file %s: %v", deltaPath, err)
 	}
@@ -202,6 +203,7 @@ func (t *TableBackup) writeSegmentToFile() error {
 	}
 	log.Printf("stored current segment to disk file %s", deltaPath)
 	t.archiveFilesQueue.Put(t.segmentFilename)
+
 	return err
 }
 
@@ -545,6 +547,7 @@ func syncFileAndDirectory(fp *os.File, path, parentDirectoryName string) error {
 	if err := fp.Sync(); err != nil {
 		return fmt.Errorf("could not sync file %s: %v", path, err)
 	}
+
 	// sync the directory entry
 	dP, err := os.Open(parentDirectoryName)
 	defer dP.Close()
@@ -554,6 +557,7 @@ func syncFileAndDirectory(fp *os.File, path, parentDirectoryName string) error {
 	if err = dP.Sync(); err != nil {
 		return fmt.Errorf("could not sync directory %s: %v", err)
 	}
+
 	return nil
 }
 

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -327,6 +327,7 @@ func (t *TableBackup) archiveCurrentSegment(reason string) error {
 	if t.segmentFilename == "" || t.deltaCnt == 0 {
 		return nil
 	}
+	log.Printf("writing and archiving current segment to %s due to the %s", t.segmentFilename, reason)
 	if err := t.writeSegmentToFile(); err != nil {
 		return err
 	}


### PR DESCRIPTION
Flush the buffer into a disk file once we have filled the delta up to a
threshold, or when the archiver decides to archive the file due to the
timeout.

Call fsync on the files and parent directory entries if fsync is on.
This is done both when the buffers are flushed, as well as when the file
is copied to the final directory.