### PR TITLE
Simplify backup table path

### DIFF
--- a/pkg/dbutils/dbutils.go
+++ b/pkg/dbutils/dbutils.go
@@ -2,6 +2,7 @@ package dbutils
 
 import (
 	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgtype"
 )
 
 type Lsn uint64
@@ -21,6 +22,16 @@ func (l *Lsn) Parse(lsn string) error {
 }
 
 type Oid uint32
+
+// implement the Scanner interface in order to allow pgx to read Oid values from the DB.
+func (o *Oid) Scan(src interface{}) error {
+	var result pgtype.OID
+	if err := result.Scan(src); err != nil {
+		return err
+	}
+	*o = Oid(result)
+	return nil
+}
 
 const (
 	InvalidOid Oid = 0

--- a/pkg/logicalbackup/logicalbackup.go
+++ b/pkg/logicalbackup/logicalbackup.go
@@ -267,6 +267,8 @@ func (b *LogicalBackup) handler(m message.Message) error {
 		//TODO:
 	case message.Truncate:
 		//TODO:
+	case message.Type:
+		//TODO: consider writing this message to all tables in a transaction as a safety measure during restore.
 	}
 
 	return err
@@ -274,7 +276,6 @@ func (b *LogicalBackup) handler(m message.Message) error {
 
 // act on a new relation message. We act on table renames, drops and recreations and new tables
 func (b *LogicalBackup) processRelationMessage(m message.Relation) error {
-	// collect what we know about this table
 	if _, isRegistered := b.backupTables[m.OID]; !isRegistered {
 		if track, err := b.registerNewTable(m); !track || err != nil {
 			if err != nil {

--- a/pkg/logicalbackup/logicalbackup.go
+++ b/pkg/logicalbackup/logicalbackup.go
@@ -579,12 +579,10 @@ func (b *LogicalBackup) prepareTablesForPublication(conn *pgx.Conn) error {
 
 		for rows.Next() {
 			tab := tableInfo{}
-			var oid uint32
-			err = rows.Scan(&oid, &tab.name.Namespace, &tab.name.Name, &tab.hasPK, &tab.replicaIdentity)
+			err = rows.Scan(&tab.oid, &tab.name.Namespace, &tab.name.Name, &tab.hasPK, &tab.replicaIdentity)
 			if err != nil {
 				return
 			}
-			tab.oid = dbutils.Oid(oid)
 
 			tables = append(tables, tab)
 		}

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -39,6 +39,20 @@ type DumpInfo struct {
 	BackupDuration float64   `json:"BackupDuration"`
 }
 
+type RelationNameWithLSN struct {
+	Name         NamespacedName
+	ValidFromLSN dbutils.Lsn
+}
+
+type OidRelationMap struct {
+	Oid      dbutils.Oid
+	Relation []RelationNameWithLSN
+}
+
+type OidMappingFile struct {
+	Relations []OidRelationMap
+}
+
 type Message interface {
 	msg()
 }

--- a/pkg/message/message.go
+++ b/pkg/message/message.go
@@ -39,20 +39,6 @@ type DumpInfo struct {
 	BackupDuration float64   `json:"BackupDuration"`
 }
 
-type RelationNameWithLSN struct {
-	Name         NamespacedName
-	ValidFromLSN dbutils.Lsn
-}
-
-type OidRelationMap struct {
-	Oid      dbutils.Oid
-	Relation []RelationNameWithLSN
-}
-
-type OidMappingFile struct {
-	Relations []OidRelationMap
-}
-
 type Message interface {
 	msg()
 }

--- a/pkg/tablebackup/basebackup.go
+++ b/pkg/tablebackup/basebackup.go
@@ -33,7 +33,10 @@ func (t *TableBackup) RunBasebackup() error {
 
 	log.Printf("Starting base backup of %s", t)
 	tempFilepath := path.Join(t.tempDir, t.infoFilename+".new")
-	if _, err := os.Stat(tempFilepath); os.IsExist(err) {
+	if _, err := os.Stat(tempFilepath); !os.IsNotExist(err) {
+		if err != nil {
+			return fmt.Errorf("could not stat %q: %v", tempFilepath, err)
+		}
 		os.Remove(tempFilepath)
 	}
 
@@ -320,7 +323,10 @@ func (t *TableBackup) copyDump() error {
 	}
 
 	tempFilename := path.Join(t.tempDir, t.basebackupFilename+".new")
-	if _, err := os.Stat(tempFilename); os.IsExist(err) {
+	if _, err := os.Stat(tempFilename); !os.IsNotExist(err) {
+		if err != nil {
+			return fmt.Errorf("could not stat %q: %v", tempFilename, err)
+		}
 		os.Remove(tempFilename)
 	}
 

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -357,17 +357,20 @@ func archiveOneFile(sourceFile, destFile string, fsync bool) error {
 	if _, err := os.Stat(sourceFile); os.IsNotExist(err) {
 		log.Printf("source file doesn't exist: %q; skipping", sourceFile)
 		return nil
+	} else if err != nil {
+		return fmt.Errorf("could not stat source file %q: %v", sourceFile, err)
 	}
 
-	if st, err := os.Stat(destFile); os.IsExist(err) {
+	if st, err := os.Stat(destFile); !os.IsNotExist(err) {
+		if err != nil {
+			return fmt.Errorf("could not stat destination file %q: %s", destFile, err)
+		}
 		if st.Size() == 0 {
 			os.Remove(destFile)
 		} else {
 			log.Printf("destination file is not empty %q; skipping", destFile)
 			return nil
 		}
-	} else if err != nil {
-		return fmt.Errorf("could not stat %s: %v", destFile, err)
 	}
 
 	if _, err := copyFile(sourceFile, destFile, fsync); err != nil {

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -57,7 +57,7 @@ type TableBackup struct {
 	wait *sync.WaitGroup
 
 	// Table info
-	oid uint32
+	oid dbutils.Oid
 
 	// Basebackup
 	tx    *pgx.Tx
@@ -100,13 +100,13 @@ type TableBackup struct {
 	archiveFilesQueue *queue.Queue
 }
 
-//TODO: maybe use oid instead of schema-name pair?
-func New(ctx context.Context, group *sync.WaitGroup, cfg *config.Config, tbl message.NamespacedName,
+func New(ctx context.Context, group *sync.WaitGroup, cfg *config.Config, tbl message.NamespacedName, oid dbutils.Oid,
 	dbCfg pgx.ConnConfig, basebackupsQueue *queue.Queue) (*TableBackup, error) {
-	tableDir := utils.TableDir(tbl)
+	tableDir := utils.TableDir(tbl, oid)
 
 	tb := TableBackup{
 		NamespacedName:      tbl,
+		oid:                 oid,
 		ctx:                 ctx,
 		wait:                group,
 		sleepBetweenBackups: time.Second * 3,

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -365,7 +365,12 @@ func archiveOneFile(sourceFile, destFile string, fsync bool) error {
 		if err != nil {
 			return fmt.Errorf("could not stat destination file %q: %s", destFile, err)
 		}
-		if st.Size() == 0 {
+		// for the basebackup we always come up with the same path, and therefore, needs to remove the previous backup
+		// if we fail, it is not an issue, since we have both basebackup and info file in the staging directory.
+		// TODO: make sure we properly archive the leftovers of.copy and info file on restart
+		if basename := path.Base(destFile); basename == basebackupFilename ||
+			basename == tableInfoFilename ||
+			st.Size() == 0 {
 			os.Remove(destFile)
 		} else {
 			log.Printf("destination file is not empty %q; skipping", destFile)

--- a/pkg/tablebackup/tablebackup.go
+++ b/pkg/tablebackup/tablebackup.go
@@ -391,9 +391,12 @@ func (t *TableBackup) Files() int {
 }
 
 func (t *TableBackup) setSegmentFilename(newLSN dbutils.Lsn) {
-	filename := path.Join(deltasDirName, fmt.Sprintf("%016x", newLSN))
+	filename := path.Join(deltasDirName, fmt.Sprintf("%016x", uint64(newLSN)))
 	// XXX: ignoring os.stat errors outside of 'file already exists'
-	if _, err := os.Stat(filename); t.lastLSN == newLSN || os.IsExist(err) {
+	if _, err := os.Stat(filename); t.lastLSN == newLSN || !os.IsNotExist(err) {
+		if err != nil {
+			fmt.Printf("could not stat %q: %s", filename, err)
+		}
 		t.filenamePostfix++
 	} else {
 		t.filenamePostfix = 0

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,22 +1,25 @@
 package utils
 
 import (
-	"crypto/md5"
 	"fmt"
+	"github.com/ikitiki/logical_backup/pkg/message"
 	"path"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ikitiki/logical_backup/pkg/dbutils"
-	"github.com/ikitiki/logical_backup/pkg/message"
 )
 
-func TableDir(tbl message.NamespacedName) string {
-	tblHash := fmt.Sprintf("%x", md5.Sum([]byte(tbl.Sanitize())))
+func TableDir(tbl message.NamespacedName, oid dbutils.Oid) string {
 
-	// TODO: consider removing tblHash altogether to shorten the path
-	return path.Join(tblHash[0:2], tblHash[2:4], tblHash[4:6], tblHash, fmt.Sprintf("%s.%s", tbl.Namespace, tbl.Name))
+	if oid == dbutils.InvalidOid {
+		panic(fmt.Sprintf("requested table directories for the table %s with invalid oid", tbl))
+	}
+
+	tblOidBytes := fmt.Sprintf("%08x", oid)
+
+	return path.Join(tblOidBytes[0:2], tblOidBytes[2:4], tblOidBytes[4:6], fmt.Sprintf("%d", oid))
 }
 
 // Retry retries a given function until either it returns false, which indicates success, or the number of attempts

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TableDir(tbl message.NamespacedName, oid dbutils.Oid) string {
-
 	if oid == dbutils.InvalidOid {
 		panic(fmt.Sprintf("requested table directories for the table %s with invalid oid", tbl))
 	}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -19,7 +19,7 @@ func TableDir(tbl message.NamespacedName, oid dbutils.Oid) string {
 
 	tblOidBytes := fmt.Sprintf("%08x", oid)
 
-	return path.Join(tblOidBytes[0:2], tblOidBytes[2:4], tblOidBytes[4:6], fmt.Sprintf("%d", oid))
+	return path.Join(tblOidBytes[6:8], tblOidBytes[4:6], tblOidBytes[2:4], fmt.Sprintf("%d", oid))
 }
 
 // Retry retries a given function until either it returns false, which indicates success, or the number of attempts

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,13 +2,13 @@ package utils
 
 import (
 	"fmt"
-	"github.com/ikitiki/logical_backup/pkg/message"
 	"path"
 	"strconv"
 	"strings"
 	"time"
 
 	"github.com/ikitiki/logical_backup/pkg/dbutils"
+	"github.com/ikitiki/logical_backup/pkg/message"
 )
 
 func TableDir(tbl message.NamespacedName, oid dbutils.Oid) string {


### PR DESCRIPTION
 use Oids instead of names in path, simplify the logic that acts on the Relation message, fixes for usage of os.stat with the wrong error code and output of the lsn type value as a string as a part of the delta path.