### PR TITLE
Persist OID to name map

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -25,7 +25,6 @@ func TableDir(tbl message.NamespacedName, oid dbutils.Oid) string {
 // Retry retries a given function until either it returns false, which indicates success, or the number of attempts
 // reach the limit, or the global timeout is reached. The cool-off period between attempts is passed as well.
 func Retry(fn func() (bool, error), numberOfAttempts int, timeBetweenAttempts time.Duration, totalTimeout time.Duration) error {
-
 	var (
 		globalTicker = time.NewTicker(totalTimeout)
 		fail         = true
@@ -50,6 +49,7 @@ func Retry(fn func() (bool, error), numberOfAttempts int, timeBetweenAttempts ti
 	if timeout {
 		return fmt.Errorf("did not succeed after %s", totalTimeout)
 	}
+
 	return fmt.Errorf("did not succeed after %d attempts", numberOfAttempts)
 }
 
@@ -61,6 +61,7 @@ func GetLSNFromDeltaFilename(filename string) (dbutils.Lsn, error) {
 	}
 
 	lsn, err := strconv.ParseUint(lsnStr, 16, 64)
+
 	return dbutils.Lsn(lsn), err
 }
 
@@ -70,12 +71,13 @@ func SyncFileAndDirectory(fp *os.File, path, parentDirectoryName string) error {
 	}
 
 	// sync the directory entry
-	dP, err := os.Open(parentDirectoryName)
-	defer dP.Close()
+	dp, err := os.Open(parentDirectoryName)
 	if err != nil {
 		return fmt.Errorf("could not open directory %s to sync: %v", parentDirectoryName, err)
 	}
-	if err = dP.Sync(); err != nil {
+	defer dp.Close()
+
+	if err = dp.Sync(); err != nil {
 		return fmt.Errorf("could not sync directory %s: %v", err)
 	}
 

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"os"
 	"path"
 	"strconv"
 	"strings"
@@ -61,4 +62,22 @@ func GetLSNFromDeltaFilename(filename string) (dbutils.Lsn, error) {
 
 	lsn, err := strconv.ParseUint(lsnStr, 16, 64)
 	return dbutils.Lsn(lsn), err
+}
+
+func SyncFileAndDirectory(fp *os.File, path, parentDirectoryName string) error {
+	if err := fp.Sync(); err != nil {
+		return fmt.Errorf("could not sync file %s: %v", path, err)
+	}
+
+	// sync the directory entry
+	dP, err := os.Open(parentDirectoryName)
+	defer dP.Close()
+	if err != nil {
+		return fmt.Errorf("could not open directory %s to sync: %v", parentDirectoryName, err)
+	}
+	if err = dP.Sync(); err != nil {
+		return fmt.Errorf("could not sync directory %s: %v", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Store the history of relation name changes in memory and flush them
on every commit that changed (or added) a name of at least one relation.