### PR TITLE
Create a proper basebackup in case when table is empty. Without this …

### DIFF
--- a/pkg/basebackup/basebackup.go
+++ b/pkg/basebackup/basebackup.go
@@ -81,11 +81,7 @@ func (b *basebackup) basebackupTable(table tablebackup.TableBackuper) error {
 	log.Printf("Starting base backup of %s", table)
 	bbTable = bbtable.New(b.cfg.DB, table)
 	if err := bbTable.Basebackup(); err != nil {
-		if err == bbtable.ErrEmptyTable {
-			log.Printf("Table %s seems to be empty; skipping", table)
-			// last backup time is not updated here
-			return nil
-		} else if err == bbtable.ErrTableNotFound {
+		if err == bbtable.ErrTableNotFound {
 			log.Printf("Table %s not found, skipping basebackup and removing from the list", table)
 			b.backupTables.Delete(table.OID())
 			return nil

--- a/pkg/basebackup/bbtable/bbtable.go
+++ b/pkg/basebackup/bbtable/bbtable.go
@@ -51,9 +51,6 @@ type tableBasebackup struct {
 }
 
 var (
-	// ErrEmptyTable represents empty table error
-	ErrEmptyTable = errors.New("empty table")
-
 	// ErrTableNotFound represents table not found error
 	ErrTableNotFound = errors.New("table not found")
 )
@@ -250,10 +247,8 @@ func (t *tableBasebackup) Basebackup() error {
 	if err := t.createTempReplicationSlot(fmt.Sprintf("tempslot_%d", t.conn.PID())); err != nil {
 		return fmt.Errorf("could not create temp replication slot: %v", err)
 	}
-	if hasRows, err := t.hasRows(); err != nil {
+	if _, err := t.hasRows(); err != nil {
 		return fmt.Errorf("could not check if table has rows: %v", err)
-	} else if !hasRows {
-		return ErrEmptyTable
 	}
 
 	t.CreateDate = time.Now()


### PR DESCRIPTION
Currently `backup` util doesn't create `basebackup_info.yaml` if table is empty. And so `resotre` fails with error:

```
could not restore table: could not load dump info: could not open file: open /tmp/final/11/41/00/16657/basebackup_info.yaml: no such file or directory
```

In this PR basebackup on empty table would not raise an error and hence create all necessary files.